### PR TITLE
Check that an overlay is visible before removing

### DIFF
--- a/lib/ots.dart
+++ b/lib/ots.dart
@@ -277,8 +277,12 @@ Future<void> _showOverlay({@required Widget child, _OverlayType type}) async {
 
 Future<void> _hideOverlay(_OverlayType type) async {
   try {
-    type.getOverlayEntry().remove();
-    type.hide();
+    if (type.isShowing()) {
+      type.getOverlayEntry().remove();
+      type.hide();
+    } else {
+      _printLog('No overlay is shown');
+    }
   } catch (err) {
     _printError(
         '''Caught an exception while trying to remove Overlay\n${err.toString()}''');

--- a/test/ots_test.dart
+++ b/test/ots_test.dart
@@ -1,13 +1,46 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ots/ots.dart';
 
 void main() {
-  test('adds one to input values', () {
-//    final calculator = Calculator();
-//    expect(calculator.addOne(2), 3);
-//    expect(calculator.addOne(-7), -6);
-//    expect(calculator.addOne(0), 1);
-//    expect(() => calculator.addOne(null), throwsNoSuchMethodError);
-  });
+  testWidgets(
+    'hideLoader does not throw when no overlay is shown',
+    (tester) async {
+      await tester.pumpWidget(
+        OTS(
+          child: MaterialApp(
+            home: Scaffold(),
+          ),
+        ),
+      );
+      await showLoader();
+      await hideLoader();
+      try {
+        await hideLoader();
+      } catch (e) {
+        fail('threw on second call to [hideLoader]');
+      }
+    },
+  );
+
+  testWidgets(
+    'hideNotification does not throw when no overlay is shown',
+    (tester) async {
+      await tester.pumpWidget(
+        OTS(
+          child: MaterialApp(
+            home: Scaffold(),
+          ),
+        ),
+      );
+      await showNotification(message: 'foo');
+      await hideNotification();
+      try {
+        await hideNotification();
+      } catch (e) {
+        fail('threw on second call to [hideNotification]');
+      }
+    },
+  );
 }


### PR DESCRIPTION
Add a guard to ensure that before `_hideOverlay` removes an overlay that
there is currently a visible entry of that overlay type. This resolves
an issue which would cause the flutter engine to throw as
`AssertionError` if either `hideLoader` or `hideNotification` are called
whilst no overlay of that type is currently showing.

closes #16