### PR TITLE
Added optional backgroundColor and textStyle to bakeToast

### DIFF
--- a/lib/ots.dart
+++ b/lib/ots.dart
@@ -420,8 +420,9 @@ extension OverlayTypeExtension on _OverlayType? {
         return "NetworkStatus";
       case _OverlayType.Toast:
         return "Toast";
+      default:
+        return "Overlay";
     }
-    return "Overlay";
   }
 
   bool isShowing() {
@@ -434,8 +435,9 @@ extension OverlayTypeExtension on _OverlayType? {
         return _networkShown;
       case _OverlayType.Toast:
         return _toastShown;
+      default:
+        return false;
     }
-    return false;
   }
 
   void setShowing() {
@@ -451,6 +453,8 @@ extension OverlayTypeExtension on _OverlayType? {
         break;
       case _OverlayType.Toast:
         _toastShown = true;
+        break;
+      default:
         break;
     }
   }
@@ -469,6 +473,8 @@ extension OverlayTypeExtension on _OverlayType? {
       case _OverlayType.Toast:
         _toastShown = false;
         break;
+      default:
+        break;
     }
   }
 
@@ -482,8 +488,9 @@ extension OverlayTypeExtension on _OverlayType? {
         return _networkStatusEntry;
       case _OverlayType.Toast:
         return _toastEntry;
+      default:
+        return null;
     }
-    return null;
   }
 
   void setOverlayEntry(OverlayEntry entry) {
@@ -499,6 +506,8 @@ extension OverlayTypeExtension on _OverlayType? {
         break;
       case _OverlayType.Toast:
         _toastEntry = entry;
+        break;
+      default:
         break;
     }
   }

--- a/lib/ots.dart
+++ b/lib/ots.dart
@@ -6,6 +6,8 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:ots/toast/colors.dart';
+import 'package:ots/toast/text_styles.dart';
 import 'package:ots/toast/types.dart';
 import 'package:ots/toast/widgets/error.dart';
 import 'package:ots/toast/widgets/info.dart';
@@ -150,9 +152,8 @@ Future<void> _showNetworkStateWidget(
     );
     _printLog("Network change: " + state.message);
     if (_OverlayType.NetworkStatus.isShowing()) {
-      _printLog(
-          "An internet overlay is being currently shown, "
-              "hiding it before showing new overlay");
+      _printLog("An internet overlay is being currently shown, "
+          "hiding it before showing new overlay");
       await _hideNetworkStateWidget();
     }
 
@@ -273,24 +274,46 @@ Future<void> hideNotification() async {
 
 ///----------------------------------Toasts------------------------------------
 Future<void> bakeToast(String message,
-    {ToastType type = ToastType.normal}) async {
+    {Color? backgroundColor,
+    TextStyle? textStyle,
+    ToastType type = ToastType.normal}) async {
   try {
     Widget? _toast;
     switch (type) {
       case ToastType.normal:
-        _toast = DefaultToast(message: message, onToasted: _hideToast);
+        _toast = DefaultToast(
+            backgroundColor: backgroundColor ?? ToastColors.defaultToastBGColor,
+            textStyle: textStyle ?? ToastTextStyle.defaultTextStyle,
+            message: message,
+            onToasted: _hideToast);
         break;
       case ToastType.info:
-        _toast = InfoToast(message: message, onToasted: _hideToast);
+        _toast = InfoToast(
+            backgroundColor: backgroundColor ?? ToastColors.infoToastBGColor,
+            textStyle: textStyle ?? ToastTextStyle.defaultTextStyle,
+            message: message,
+            onToasted: _hideToast);
         break;
       case ToastType.success:
-        _toast = SuccessToast(message: message, onToasted: _hideToast);
+        _toast = SuccessToast(
+            backgroundColor: backgroundColor ?? ToastColors.successToastBGColor,
+            textStyle: textStyle ?? ToastTextStyle.defaultTextStyle,
+            message: message,
+            onToasted: _hideToast);
         break;
       case ToastType.error:
-        _toast = ErrorToast(message: message, onToasted: _hideToast);
+        _toast = ErrorToast(
+            backgroundColor: backgroundColor ?? ToastColors.errorToastBGColor,
+            textStyle: textStyle ?? ToastTextStyle.defaultTextStyle,
+            message: message,
+            onToasted: _hideToast);
         break;
       case ToastType.warning:
-        _toast = WarningToast(message: message, onToasted: _hideToast);
+        _toast = WarningToast(
+            backgroundColor: backgroundColor ?? ToastColors.warningToastBGColor,
+            textStyle: textStyle ?? ToastTextStyle.defaultTextStyle,
+            message: message,
+            onToasted: _hideToast);
         break;
     }
 

--- a/lib/toast/widgets/error.dart
+++ b/lib/toast/widgets/error.dart
@@ -5,8 +5,8 @@ import 'package:ots/toast/length.dart';
 import 'package:ots/toast/text_styles.dart';
 
 class ErrorToast extends StatefulWidget {
-  final Color backgroundColor;
-  final TextStyle textStyle;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
   final String message;
   final int duration;
   final VoidCallback? onToasted;

--- a/lib/toast/widgets/info.dart
+++ b/lib/toast/widgets/info.dart
@@ -5,8 +5,8 @@ import 'package:ots/toast/length.dart';
 import 'package:ots/toast/text_styles.dart';
 
 class InfoToast extends StatefulWidget {
-  final Color backgroundColor;
-  final TextStyle textStyle;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
   final String message;
   final int duration;
   final VoidCallback? onToasted;

--- a/lib/toast/widgets/normal.dart
+++ b/lib/toast/widgets/normal.dart
@@ -5,8 +5,8 @@ import 'package:ots/toast/length.dart';
 import 'package:ots/toast/text_styles.dart';
 
 class DefaultToast extends StatefulWidget {
-  final Color backgroundColor;
-  final TextStyle textStyle;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
   final String message;
   final int duration;
   final VoidCallback? onToasted;
@@ -38,6 +38,10 @@ class _DefaultToastState extends State<DefaultToast>
         curve: Curves.easeInCirc,
         reverseCurve: Curves.easeOutCirc,
         parent: _fadeController));
+
+    if (widget.backgroundColor == null) {
+      print("No background passed so use default color");
+    }
 
     _initAnimation();
   }

--- a/lib/toast/widgets/normal.dart
+++ b/lib/toast/widgets/normal.dart
@@ -39,10 +39,6 @@ class _DefaultToastState extends State<DefaultToast>
         reverseCurve: Curves.easeOutCirc,
         parent: _fadeController));
 
-    if (widget.backgroundColor == null) {
-      print("No background passed so use default color");
-    }
-
     _initAnimation();
   }
 

--- a/lib/toast/widgets/success.dart
+++ b/lib/toast/widgets/success.dart
@@ -5,8 +5,8 @@ import 'package:ots/toast/length.dart';
 import 'package:ots/toast/text_styles.dart';
 
 class SuccessToast extends StatefulWidget {
-  final Color backgroundColor;
-  final TextStyle textStyle;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
   final String message;
   final int duration;
   final VoidCallback? onToasted;

--- a/lib/toast/widgets/warning.dart
+++ b/lib/toast/widgets/warning.dart
@@ -5,8 +5,8 @@ import 'package:ots/toast/length.dart';
 import 'package:ots/toast/text_styles.dart';
 
 class WarningToast extends StatefulWidget {
-  final Color backgroundColor;
-  final TextStyle textStyle;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
   final String message;
   final int duration;
   final VoidCallback? onToasted;


### PR DESCRIPTION
I added backgroundColor and textStyle as optional to the bakeToast. This way the user can override the background color and text styles shown for the toast for all toast types. If the user does not provide a backgroundColor or textStyle then I default to the backgroundColor and textStyles used for each different type of toast. But this way users have more flexibility and can also use normal type with background color as their error toast if they do not want to display icons.