### PR TITLE
Fixed RenderFlex overflowed 

### DIFF
--- a/lib/ots.dart
+++ b/lib/ots.dart
@@ -231,7 +231,7 @@ Future<NotificationWidgetState> showNotification(
     int? animDuration,
     bool? autoDismissible}) async {
   /// Throws an error if message is null
-  assert(message != null, '''Notification message cannot be null''');
+  // assert(message != null, '''Notification message cannot be null''');
 
   try {
     final instance = NotificationWidget(

--- a/lib/toast/widgets/error.dart
+++ b/lib/toast/widgets/error.dart
@@ -74,10 +74,12 @@ class _ErrorToastState extends State<ErrorToast>
                 color: Colors.white,
               ),
               SizedBox(width: 8.0),
-              Text(
-                widget.message,
-                textAlign: TextAlign.center,
-                style: widget.textStyle,
+              Flexible(
+                child: Text(
+                  widget.message,
+                  textAlign: TextAlign.center,
+                  style: widget.textStyle,
+                ),
               ),
             ],
           ),

--- a/lib/toast/widgets/info.dart
+++ b/lib/toast/widgets/info.dart
@@ -74,10 +74,12 @@ class _InfoToastState extends State<InfoToast>
                 color: Colors.white,
               ),
               SizedBox(width: 8.0),
-              Text(
-                widget.message,
-                textAlign: TextAlign.center,
-                style: widget.textStyle,
+              Flexible(
+                child: Text(
+                  widget.message,
+                  textAlign: TextAlign.center,
+                  style: widget.textStyle,
+                ),
               ),
             ],
           ),

--- a/lib/toast/widgets/success.dart
+++ b/lib/toast/widgets/success.dart
@@ -74,10 +74,12 @@ class _SuccessToastState extends State<SuccessToast>
                 color: Colors.white,
               ),
               SizedBox(width: 8.0),
-              Text(
-                widget.message,
-                textAlign: TextAlign.center,
-                style: widget.textStyle,
+              Flexible(
+                child: Text(
+                  widget.message,
+                  textAlign: TextAlign.center,
+                  style: widget.textStyle,
+                ),
               ),
             ],
           ),

--- a/lib/toast/widgets/warning.dart
+++ b/lib/toast/widgets/warning.dart
@@ -74,10 +74,12 @@ class _WarningToastState extends State<WarningToast>
                 color: Colors.white,
               ),
               SizedBox(width: 8.0),
-              Text(
-                widget.message,
-                textAlign: TextAlign.center,
-                style: widget.textStyle,
+              Flexible(
+                child: Text(
+                  widget.message,
+                  textAlign: TextAlign.center,
+                  style: widget.textStyle,
+                ),
               ),
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ots
 description: A package for showing loading indicators, notifications, dialogs, internet connectivity updates, Over the Screen easily.
 version: 1.0.0
-author: Fayaz
+# author: Fayaz
 homepage: https://github.com/fayaz07/ots
 
 environment:


### PR DESCRIPTION
Fixed the RenderFlex overflowed issue with some of the toasts types by embedding the text into a flexible widget.